### PR TITLE
[Initial Part 11] Add Methods to EloquentController for Updating To-Many Relationships

### DIFF
--- a/app/Http/Controllers/Api/ContributorsController.php
+++ b/app/Http/Controllers/Api/ContributorsController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers\Api;
 
 use App\Contributor;
 use App\JsonApi\Contributors;
-use CloudCreativity\LaravelJsonApi\Http\Controllers\EloquentController;
 
 class ContributorsController extends EloquentController
 {

--- a/app/Http/Controllers/Api/EloquentController.php
+++ b/app/Http/Controllers/Api/EloquentController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use CloudCreativity\JsonApi\Contracts\Http\Requests\RequestInterface;
+use Illuminate\Http\Response;
+use CloudCreativity\LaravelJsonApi\Http\Controllers\EloquentController as BaseEloquentController;
+
+class EloquentController extends BaseEloquentController
+{
+    /**
+     * @param RequestInterface $request
+     * @return Response
+     */
+    public function replaceRelationship(RequestInterface $request)
+    {
+        $model = $this->getRecord($request);
+        $key = $this->keyForRelationship($request->getRelationshipName());
+
+        $store = $this->api()->getStore();
+        $relatedModels = [];
+        foreach($request->getDocument()->getResources()->getAll() as $resourceObject) {
+            $relatedModels[] = $store->findRecord($resourceObject->getIdentifier());
+        }
+        $model->{$key}()->detach();
+        $model->{$key}()->saveMany($relatedModels);
+
+        return $this
+            ->reply()
+            ->relationship($model->{$key});
+    }
+
+    /**
+     * @param RequestInterface $request
+     * @return Response
+     */
+    public function removeFromRelationship(RequestInterface $request)
+    {
+        $model = $this->getRecord($request);
+        $key = $this->keyForRelationship($request->getRelationshipName());
+
+        $relatedIds = [];
+        foreach($request->getDocument()->getResources()->getAll() as $resourceObject) {
+            $relatedIds[] = $resourceObject->getId();
+        }
+        $model->{$key}()->detach($relatedIds);
+
+        return $this
+            ->reply()
+            ->relationship($model->{$key});
+    }
+
+    /**
+     * @param RequestInterface $request
+     * @return Response
+     */
+    public function addToRelationship(RequestInterface $request)
+    {
+        $model = $this->getRecord($request);
+        $key = $this->keyForRelationship($request->getRelationshipName());
+
+        $store = $this->api()->getStore();
+        $relatedModels = [];
+        $existingIds = $model->{$key}()->allRelatedIds()->all();
+        foreach($request->getDocument()->getResources()->getAll() as $resourceObject) {
+            if(!in_array($resourceObject->getId(), $existingIds)) {
+                $relatedModels[] = $store->findRecord($resourceObject->getIdentifier());
+            }
+        }
+        $model->{$key}()->saveMany($relatedModels);
+
+        return $this
+            ->reply()
+            ->relationship($model->{$key});
+    }
+}

--- a/app/Http/Controllers/Api/PodcastsController.php
+++ b/app/Http/Controllers/Api/PodcastsController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers\Api;
 
 use App\JsonApi\Podcasts;
 use App\Podcast;
-use CloudCreativity\LaravelJsonApi\Http\Controllers\EloquentController;
 
 class PodcastsController extends EloquentController
 {

--- a/app/JsonApi/Contributors/Schema.php
+++ b/app/JsonApi/Contributors/Schema.php
@@ -44,6 +44,14 @@ class Schema extends EloquentSchema
         }
 
         return [
+            'podcasts' => [
+                self::SHOW_SELF => true,
+                self::SHOW_RELATED => true,
+                self::META => function () use ($resource) {
+                    return ['total' => $resource->podcasts()->count()];
+                },
+                self::DATA => $resource->podcasts,
+            ],
         ];
     }
 

--- a/app/JsonApi/Podcasts/Schema.php
+++ b/app/JsonApi/Podcasts/Schema.php
@@ -41,6 +41,15 @@ class Schema extends EloquentSchema
         }
 
         return [
+            'contributors' => [
+                self::SHOW_SELF => true,
+                self::SHOW_RELATED => true,
+                self::META => function () use ($resource) {
+                    return ['total' => $resource->contributors()->count()];
+                },
+                self::DATA => isset($includeRelationships['contributors']) ?
+                    $resource->contributors : $this->createBelongsToIdentity($resource, 'contributors'),
+            ],
         ];
     }
 
@@ -50,6 +59,7 @@ class Schema extends EloquentSchema
     public function getIncludePaths()
     {
         return [
+            'contributors'
         ];
     }
 }

--- a/tests/Feature/ApiTestCase.php
+++ b/tests/Feature/ApiTestCase.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 
 use CloudCreativity\LaravelJsonApi\Testing\InteractsWithModels;
 use CloudCreativity\LaravelJsonApi\Testing\MakesJsonApiRequests;
+use CloudCreativity\LaravelJsonApi\Testing\TestResponse;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tests\TestCase as BaseTestCase;
 
@@ -18,4 +19,85 @@ class ApiTestCase extends BaseTestCase
      * @var string
      */
     protected $api = 'v1';
+
+    /**
+     * @param mixed $resourceId
+     * @param string $relationshipKey
+     * @param array $params
+     * @param array $headers
+     * @return TestResponse
+     */
+    protected function doReadRelatedResources($resourceId, $relationshipKey, array $params = [], array $headers = [])
+    {
+        $params = $this->addDefaultRouteParams($params);
+        $uri = $this->api()->url()->relatedResource($this->resourceType(), $resourceId, $relationshipKey, $params);
+
+        return $this->getJsonApi($uri, [], $headers);
+    }
+
+    /**
+     * @param mixed $resourceId
+     * @param string $relationshipKey
+     * @param string $relatedType
+     * @param array $relatedIds
+     * @param array $params
+     * @param array $headers
+     * @return TestResponse
+     */
+    protected function doAddRelatedResources($resourceId, $relationshipKey, $relatedType, array $relatedIds, array $params = [], array $headers = [])
+    {
+        $params = $this->addDefaultRouteParams($params);
+        $uri = $this->api()->url()->readRelationship($this->resourceType(), $resourceId, $relationshipKey, $params);
+
+        $data = [];
+        foreach ($relatedIds as $relatedId) {
+            $data[] = ['type' => $relatedType, 'id' => (string) $relatedId];
+        }
+
+        return $this->postJsonApi($uri, ['data' => $data], $headers);
+    }
+
+    /**
+     * @param mixed $resourceId
+     * @param string $relationshipKey
+     * @param string $relatedType
+     * @param array $relatedIds
+     * @param array $params
+     * @param array $headers
+     * @return TestResponse
+     */
+    protected function doRemoveRelatedResources($resourceId, $relationshipKey, $relatedType, array $relatedIds, array $params = [], array $headers = [])
+    {
+        $params = $this->addDefaultRouteParams($params);
+        $uri = $this->api()->url()->readRelationship($this->resourceType(), $resourceId, $relationshipKey, $params);
+
+        $data = [];
+        foreach ($relatedIds as $relatedId) {
+            $data[] = ['type' => $relatedType, 'id' => (string) $relatedId];
+        }
+
+        return $this->deleteJsonApi($uri, ['data' => $data], $headers);
+    }
+
+    /**
+     * @param mixed $resourceId
+     * @param string $relationshipKey
+     * @param string $relatedType
+     * @param array $relatedIds
+     * @param array $params
+     * @param array $headers
+     * @return TestResponse
+     */
+    protected function doReplaceRelatedResources($resourceId, $relationshipKey, $relatedType, array $relatedIds, array $params = [], array $headers = [])
+    {
+        $params = $this->addDefaultRouteParams($params);
+        $uri = $this->api()->url()->readRelationship($this->resourceType(), $resourceId, $relationshipKey, $params);
+
+        $data = [];
+        foreach ($relatedIds as $relatedId) {
+            $data[] = ['type' => $relatedType, 'id' => (string) $relatedId];
+        }
+
+        return $this->patchJsonApi($uri, ['data' => $data], $headers);
+    }
 }

--- a/tests/Feature/ContributorsTest.php
+++ b/tests/Feature/ContributorsTest.php
@@ -90,6 +90,14 @@ class ContributorsTest extends ApiTestCase
                 'twitter' => $model->twitter,
                 'facebook' => $model->facebook,
             ],
+            'relationships' => [
+                'podcasts' => [
+                    'data' => $podcastsData,
+                    'meta' => [
+                        'total' => count($podcastsData)
+                    ]
+                ]
+            ]
         ];
 
         $this->doRead($model)
@@ -127,6 +135,88 @@ class ContributorsTest extends ApiTestCase
 
         $this->doDelete($model)->assertDeleteResponse();
         $this->assertModelDeleted($model);
+    }
+
+    /**
+     * Test the read podcasts route.
+     */
+    public function testReadPodcasts()
+    {
+        $model = $this->model();
+
+        $this->doReadRelatedResources($model, 'podcasts')
+            ->assertRelatedResourcesResponse(['podcasts']);
+    }
+
+    /**
+     * Test the read podcasts route.
+     */
+    public function testAddPodcasts()
+    {
+        $model = $this->model();
+
+        $relatedModels = $model->podcasts->all();
+        $relatedModelsToAdd = factory(Podcast::class, 3)->create()->all();
+
+        $relatedIds = [];
+        foreach ($relatedModelsToAdd as $relatedModel) {
+            $relatedIds[] = $relatedModel->getKey();
+        }
+
+        $response = $this->doAddRelatedResources($model, 'podcasts', 'podcasts', $relatedIds);
+
+        $relationships = [];
+        foreach (array_merge($relatedModels, $relatedModelsToAdd) as $relatedModel) {
+            $relationships[] = ['type' => 'podcasts', 'id' => (string) $relatedModel->getKey()];
+        }
+        $response->assertRelatedResourcesResponse(['podcasts'])->assertExactJson([
+            'data' => $relationships
+        ]);
+    }
+
+    /**
+     * Test the read podcasts route.
+     */
+    public function testRemovePodcasts()
+    {
+        $model = $this->model();
+
+        $relatedModels = $model->podcasts->all();
+        $relatedModelToRemove = array_pop($relatedModels);
+        $response = $this->doRemoveRelatedResources($model, 'podcasts', 'podcasts', [$relatedModelToRemove->getKey()]);
+
+        $relationships = [];
+        foreach ($relatedModels as $relatedModel) {
+            $relationships[] = ['type' => 'podcasts', 'id' => (string) $relatedModel->getKey()];
+        }
+        $response->assertRelatedResourcesResponse(['podcasts'])->assertExactJson([
+            'data' => $relationships
+        ]);
+    }
+
+    /**
+     * Test the read podcasts route.
+     */
+    public function testReplacePodcasts()
+    {
+        $model = $this->model();
+
+        $relatedModelsToReplaceWith = (array) factory(Podcast::class, 3)->create()->all();
+
+        $relatedIds = [];
+        foreach ($relatedModelsToReplaceWith as $relatedModel) {
+            $relatedIds[] = $relatedModel->getKey();
+        }
+
+        $response = $this->doReplaceRelatedResources($model, 'podcasts', 'podcasts', $relatedIds);
+
+        $relationships = [];
+        foreach ($relatedModelsToReplaceWith as $relatedModel) {
+            $relationships[] = ['type' => 'podcasts', 'id' => (string) $relatedModel->getKey()];
+        }
+        $response->assertRelatedResourcesResponse(['podcasts'])->assertExactJson([
+            'data' => $relationships
+        ]);
     }
 
     /**

--- a/tests/Feature/PodcastsTest.php
+++ b/tests/Feature/PodcastsTest.php
@@ -86,6 +86,14 @@ class PodcastsTest extends ApiTestCase
                 'description' => $model->description,
                 'image-url' => $model->image_url
             ],
+            'relationships' => [
+                'contributors' => [
+                    'data' => $contributorsData,
+                    'meta' => [
+                        'total' => count($contributorsData)
+                    ]
+                ]
+            ]
         ];
 
         $this->doRead($model)
@@ -123,6 +131,88 @@ class PodcastsTest extends ApiTestCase
 
         $this->doDelete($model)->assertDeleteResponse();
         $this->assertModelDeleted($model);
+    }
+
+    /**
+     * Test the read contributors route.
+     */
+    public function testReadContributors()
+    {
+        $model = $this->model();
+
+        $this->doReadRelatedResources($model, 'contributors')
+            ->assertRelatedResourcesResponse(['contributors']);
+    }
+
+    /**
+     * Test the read contributors route.
+     */
+    public function testAddContributors()
+    {
+        $model = $this->model();
+
+        $relatedModels = $model->contributors->all();
+        $relatedModelsToAdd = factory(Contributor::class, 3)->create()->all();
+
+        $relatedIds = [];
+        foreach ($relatedModelsToAdd as $relatedModel) {
+            $relatedIds[] = $relatedModel->getKey();
+        }
+
+        $response = $this->doAddRelatedResources($model, 'contributors', 'contributors', $relatedIds);
+
+        $relationships = [];
+        foreach (array_merge($relatedModels, $relatedModelsToAdd) as $relatedModel) {
+            $relationships[] = ['type' => 'contributors', 'id' => (string) $relatedModel->getKey()];
+        }
+        $response->assertRelatedResourcesResponse(['contributors'])->assertExactJson([
+            'data' => $relationships
+        ]);
+    }
+
+    /**
+     * Test the read contributors route.
+     */
+    public function testRemoveContributors()
+    {
+        $model = $this->model();
+
+        $relatedModels = $model->contributors->all();
+        $relatedModelToRemove = array_pop($relatedModels);
+        $response = $this->doRemoveRelatedResources($model, 'contributors', 'contributors', [$relatedModelToRemove->getKey()]);
+
+        $relationships = [];
+        foreach ($relatedModels as $relatedModel) {
+            $relationships[] = ['type' => 'contributors', 'id' => (string) $relatedModel->getKey()];
+        }
+        $response->assertRelatedResourcesResponse(['contributors'])->assertExactJson([
+            'data' => $relationships
+        ]);
+    }
+
+    /**
+     * Test the read contributors route.
+     */
+    public function testReplaceContributors()
+    {
+        $model = $this->model();
+
+        $relatedModelsToReplaceWith = (array) factory(Contributor::class, 3)->create()->all();
+
+        $relatedIds = [];
+        foreach ($relatedModelsToReplaceWith as $relatedModel) {
+            $relatedIds[] = $relatedModel->getKey();
+        }
+
+        $response = $this->doReplaceRelatedResources($model, 'contributors', 'contributors', $relatedIds);
+
+        $relationships = [];
+        foreach ($relatedModelsToReplaceWith as $relatedModel) {
+            $relationships[] = ['type' => 'contributors', 'id' => (string) $relatedModel->getKey()];
+        }
+        $response->assertRelatedResourcesResponse(['contributors'])->assertExactJson([
+            'data' => $relationships
+        ]);
     }
 
     /**


### PR DESCRIPTION
These methods are missing from the cloudcreativity/laravel-json-api package, even though the routes for them are setup. I've created replaceRelationship, removeFromRelationship, and addToRelationship to allow PATCH, DELETE, and POST requests to a relationship route. I've followed the specification here: http://jsonapi.org/format/#crud-updating-relationships.

I also built tests for these routes by adding more "do" methods to the ApiTestCase class.